### PR TITLE
Refactor: Add support for HID collections in GenericUps

### DIFF
--- a/src/HidUps/UpsUsage.cs
+++ b/src/HidUps/UpsUsage.cs
@@ -10,6 +10,13 @@ namespace HidUps
         PowerDevicePage = 0x00840000,
         Ups = 0x00840004,
         PowerSupply = 0x00840005,
+
+        // -- Collection Usages --
+        InputCollection = 0x0084001A,
+        OutputCollection = 0x0084001C,
+        BatteryCollection = 0x00840012,
+
+        // -- Measurement Usages --
         Voltage = 0x00840030,
         Frequency = 0x00840032,
         ApparentPower = 0x00840033,


### PR DESCRIPTION
The GenericUps class has been refactored to correctly handle HID devices that use the same usage page and ID in different collections.

- The internal usage map now uses a composite key of (collection usage, item usage) to uniquely identify a control.
- The HID report descriptor parser now recursively traverses the collection hierarchy to correctly identify the context for each usage.
- Public properties have been updated to be unambiguous, providing specific values for input, output, and battery contexts (e.g., InputVoltage, OutputVoltage).